### PR TITLE
Update visual studio tools for unity to version 3.8.0.7 

### DIFF
--- a/visual-studio-2015-tools-for-unity/ReadMe.md
+++ b/visual-studio-2015-tools-for-unity/ReadMe.md
@@ -6,40 +6,40 @@ always try to ensure you have read, understood and adhere to the create
 packages wiki link above.
 
 ## Automatic Packaging Updates?
-Consider making this package an automatic package, for the best 
+Consider making this package an automatic package, for the best
 maintainability over time. Read up at https://chocolatey.org/docs/automatic-packages
 
 ## Shim Generation
-Any executables you include in the package or download (but don't call 
+Any executables you include in the package or download (but don't call
 install against using the built-in functions) will be automatically shimmed.
 
 This means those executables will automatically be included on the path.
-Shim generation runs whether the package is self-contained or uses automation 
-scripts. 
+Shim generation runs whether the package is self-contained or uses automation
+scripts.
 
 By default, these are considered console applications.
 
-If the application is a GUI, you should create an empty file next to the exe 
+If the application is a GUI, you should create an empty file next to the exe
 named 'name.exe.gui' e.g. 'bob.exe' would need a file named 'bob.exe.gui'.
 See https://chocolatey.org/docs/create-packages#how-do-i-set-up-shims-for-applications-that-have-a-gui
 
-If you want to ignore the executable, create an empty file next to the exe 
-named 'name.exe.ignore' e.g. 'bob.exe' would need a file named 
-'bob.exe.ignore'. 
+If you want to ignore the executable, create an empty file next to the exe
+named 'name.exe.ignore' e.g. 'bob.exe' would need a file named
+'bob.exe.ignore'.
 See https://chocolatey.org/docs/create-packages#how-do-i-exclude-executables-from-getting-shims
 
-## Self-Contained? 
-If you have a self-contained package, you can remove the automation scripts 
-entirely and just include the executables, they will automatically get shimmed, 
-which puts them on the path. Ensure you have the legal right to distribute 
-the application though. See https://chocolatey.org/docs/legal. 
+## Self-Contained?
+If you have a self-contained package, you can remove the automation scripts
+entirely and just include the executables, they will automatically get shimmed,
+which puts them on the path. Ensure you have the legal right to distribute
+the application though. See https://chocolatey.org/docs/legal.
 
-You should read up on the Shim Generation section to familiarize yourself 
+You should read up on the Shim Generation section to familiarize yourself
 on what to do with GUI applications and/or ignoring shims.
 
 ## Automation Scripts
 You have a powerful use of Chocolatey, as you are using PowerShell. So you
-can do just about anything you need. Choco has some very handy built-in 
+can do just about anything you need. Choco has some very handy built-in
 functions that you can use, these are sometimes called the helpers.
 
 ### Built-In Functions
@@ -70,8 +70,8 @@ Chocolatey makes a number of environment variables available (You can access any
 The following are more advanced settings:
 
  * ChocolateyPackageParameters - Parameters to use with packaging, not the same as install arguments (which are passed directly to the native installer). Based on `--package-parameters`. (0.9.8.22+)
- * CHOCOLATEY_VERSION - The version of Choco you normally see. Use if you are 'lighting' things up based on choco version. (0.9.9+) - Otherwise take a dependency on the specific version you need. 
- * ChocolateyForceX86 = If available and set to 'true', then user has requested 32bit version. (0.9.9+) - Automatically handled in built in Choco functions. 
+ * CHOCOLATEY_VERSION - The version of Choco you normally see. Use if you are 'lighting' things up based on choco version. (0.9.9+) - Otherwise take a dependency on the specific version you need.
+ * ChocolateyForceX86 = If available and set to 'true', then user has requested 32bit version. (0.9.9+) - Automatically handled in built in Choco functions.
  * OS_PLATFORM - Like Windows, OSX, Linux. (0.9.9+)
  * OS_VERSION - The version of OS, like 6.1 something something for Windows. (0.9.9+)
  * OS_NAME - The reported name of the OS. (0.9.9+)
@@ -97,10 +97,10 @@ Some environment variables are set based on options that are passed, configurati
 
  * ChocolateyInstallArgumentsSensitive - Encrypted arguments passed from command line `--install-arguments-sensitive` that are not logged anywhere. (0.10.1+ and licensed editions 1.6.0+)
  * ChocolateyPackageParametersSensitive - Package parameters passed from command line `--package-parameters-senstivite` that are not logged anywhere.  (0.10.1+ and licensed editions 1.6.0+)
- * ChocolateyLicensedVersion - What version is the licensed edition on? 
+ * ChocolateyLicensedVersion - What version is the licensed edition on?
  * ChocolateyLicenseType - What edition / type of the licensed edition is installed?
  * USER_CONTEXT - The original user context - different when self-service is used (Licensed v1.10.0+)
- 
+
 #### Experimental Environment Variables
 The following are experimental or use not recommended:
 

--- a/visual-studio-2015-tools-for-unity/tools/chocolateyinstall.ps1
+++ b/visual-studio-2015-tools-for-unity/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿$ErrorActionPreference = 'Stop'; # stop on all errors
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'https://sebastienlebreton.gallerycdn.vsassets.io/extensions/sebastienlebreton/visualstudio2015toolsforunity/3.3.0.2/1502836519772/142077/18/vstu2015.msi'
+$url        = 'https://sebastienlebreton.gallerycdn.vsassets.io/extensions/sebastienlebreton/visualstudio2015toolsforunity/3.8.0.7/1537824503275/vstu2015.msi'
 
 $packageArgs = @{
   packageName   = $env:ChocolateyPackageName
@@ -10,7 +10,7 @@ $packageArgs = @{
 
   softwareName  = 'Microsoft Visual Studio 2015 Tools for Unity'
 
-  checksum      = '04262AA46B9FFC6ED3BA28CF45D7B78D24E1604B0C9E6B3C5CE721AF9B139A8E'
+  checksum      = '8faabccbb349d6f7fca0db6b9301efb500bce1c251d877e974d7b3cec9286c6e'
   checksumType  = 'sha256'
 
   silentArgs    = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`"" # ALLUSERS=1 DISABLEDESKTOPSHORTCUT=1 ADDDESKTOPICON=0 ADDSTARTMENU=0

--- a/visual-studio-2015-tools-for-unity/tools/chocolateyuninstall.ps1
+++ b/visual-studio-2015-tools-for-unity/tools/chocolateyuninstall.ps1
@@ -10,22 +10,22 @@ $packageArgs = @{
 $uninstalled = $false
 # Get-UninstallRegistryKey is new to 0.9.10, if supporting 0.9.9.x and below,
 # take a dependency on "chocolatey-core.extension" in your nuspec file.
-# This is only a fuzzy search if $softwareName includes '*'. Otherwise it is 
+# This is only a fuzzy search if $softwareName includes '*'. Otherwise it is
 # exact. In the case of versions in key names, we recommend removing the version
 # and using '*'.
 [array]$key = Get-UninstallRegistryKey -SoftwareName $packageArgs['softwareName']
 
 if ($key.Count -eq 1) {
-  $key | % { 
+  $key | % {
     $packageArgs['file'] = "$($_.UninstallString)"
     if ($packageArgs['fileType'] -eq 'MSI') {
-      # The Product Code GUID is all that should be passed for MSI, and very 
-      # FIRST, because it comes directly after /x, which is already set in the 
+      # The Product Code GUID is all that should be passed for MSI, and very
+      # FIRST, because it comes directly after /x, which is already set in the
       # Uninstall-ChocolateyPackage msiargs (facepalm).
       $packageArgs['silentArgs'] = "$($_.PSChildName) $($packageArgs['silentArgs'])"
-      
-      # Don't pass anything for file, it is ignored for msi (facepalm number 2) 
-      # Alternatively if you need to pass a path to an msi, determine that and 
+
+      # Don't pass anything for file, it is ignored for msi (facepalm number 2)
+      # Alternatively if you need to pass a path to an msi, determine that and
       # use it instead of the above in silentArgs, still very first
       $packageArgs['file'] = ''
     }

--- a/visual-studio-2015-tools-for-unity/visual-studio-2015-tools-for-unity.nuspec
+++ b/visual-studio-2015-tools-for-unity/visual-studio-2015-tools-for-unity.nuspec
@@ -3,13 +3,13 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>visual-studio-2015-tools-for-unity</id>
-    <version>3.3.0.2</version>
+    <version>3.8.0.7</version>
     <packageSourceUrl>https://github.com/improbable-io/chocopackages/tree/master/visual-studio-2015-tools-for-unity</packageSourceUrl>
     <owners>petemounce,improbable</owners>
     <title>Visual Studio 2015 Tools for Unity</title>
     <authors>Unity</authors>
     <projectUrl>https://docs.microsoft.com/en-us/visualstudio/cross-platform/visual-studio-tools-for-unity</projectUrl>
-    <iconUrl>https://sebastienlebreton.gallerycdn.vsassets.io/extensions/sebastienlebreton/visualstudio2015toolsforunity/3.3.0.2/1502836519772/Microsoft.VisualStudio.Services.Icons.Default</iconUrl>
+    <iconUrl>https://sebastienlebreton.gallerycdn.vsassets.io/extensions/sebastienlebreton/visualstudio2015toolsforunity/3.8.0.7/1537824503275/Microsoft.VisualStudio.Services.Icons.Default</iconUrl>
     <docsUrl>https://docs.microsoft.com/en-us/visualstudio/cross-platform/overview-of-visual-studio-tools-for-unity</docsUrl>
     <tags>visualstudio extension unity</tags>
     <summary>Visual Studio 2015 Tools for Unity extension</summary>


### PR DESCRIPTION
# Background 

We have noticed some failures installing this package recently where the latest version does not.

CDN does host the file for the existing file any more. 

# Additional Info 

## Package Source 

Package Source can be obtained from the Choco Site and resolves to the following URL 

```
https://sebastienlebreton.gallerycdn.vsassets.io/extensions/sebastienlebreton/visualstudio2015toolsforunity/3.8.0.7/1537824503275/vstu2015.msi
```

## Checksum 

The Checksum is sha256 derived from `openssl sha256 $Filename`



